### PR TITLE
adding support for fenced blocks indented due to nesting

### DIFF
--- a/src/Text/Markdown/Unlit.hs
+++ b/src/Text/Markdown/Unlit.hs
@@ -108,14 +108,16 @@ parse = go . zip [2..] . lines
         (cb, rest) -> cb : go rest
 
     takeCB :: Line -> [Line] -> (CodeBlock, [Line])
-    takeCB (n, fence) xs = case break isFence xs of
-      (cb, rest) -> (CodeBlock (parseClasses fence) (map snd cb) n, drop 1 rest)
+    takeCB (n, fence) xs =
+      let indent = length . takeWhile isSpace $ fence
+      in case break isFence xs of
+        (cb, rest) -> (CodeBlock (parseClasses fence) (map (drop indent . snd) cb) n, drop 1 rest)
 
     isFence :: Line -> Bool
-    isFence = isPrefixOf "~~~" . snd
+    isFence = isPrefixOf "~~~" . dropWhile isSpace . snd
 
 parseClasses :: String -> [String]
-parseClasses xs = case dropWhile isSpace . dropWhile (== '~') $ xs of
+parseClasses xs = case dropWhile isSpace . dropWhile (== '~') . dropWhile isSpace $ xs of
   '{':ys -> words . replace '.' ' ' . takeWhile (/= '}') $ ys
   _      -> []
 

--- a/test/Text/Markdown/UnlitSpec.hs
+++ b/test/Text/Markdown/UnlitSpec.hs
@@ -186,6 +186,16 @@ spec = do
         "some other text"
       `shouldBe` [["some", "code"]]
 
+    it "parses an indented code block" $ do
+      map codeBlockContent . parse . build $ do
+        "1. some text"
+        "    ~~~"
+        "    some"
+        "      code"
+        "    ~~~"
+        "2. some other text"
+      `shouldBe` [["some", "  code"]]
+
     it "parses an empty code block" $ do
       map codeBlockContent . parse . build $ do
         "some text"
@@ -200,6 +210,16 @@ spec = do
         "some code"
         "~~~"
       `shouldBe` [["haskell", "literate"]]
+
+    it "attaches classes to indented code blocks" $ do
+      map codeBlockClasses . parse . build $ do
+        "1. some text"
+        "    ~~~ {.haskell .literate}"
+        "    some code"
+        "    ~~~"
+        "2. some other text"
+      `shouldBe` [["haskell", "literate"]]
+
 
     it "attaches source locations to code blocks" $ do
       map codeBlockStartLine . parse . build $ do


### PR DESCRIPTION
Since `markdown-unlit` doesn't yet support codeblocks marked off by pure indentation, it's pretty easy to let it support fenced codeblocks that are indented due to nesting.

For example, this is perfectly legal markdown that contains a nested fenced codeblock.

```markdown
1.  I'm the first item in a list

    ~~~ {.haskell}
    main = return ()
    ~~~

    supporting description of above code.

2.  I'm the second item in a list
```

It's worth discussing whether this will break `markdown-unlit` for users who had been relying on the lack of support for indented codeblocks to automatically hide them from `markdown-unlit`, or make it harder to add support for unfenced codeblocks in the future.