### PR TITLE
Always use UTF-8 to read and write files

### DIFF
--- a/src/Text/Markdown/Unlit.hs
+++ b/src/Text/Markdown/Unlit.hs
@@ -42,13 +42,15 @@ run args =
   --
   case break (== "-h") args of
     (xs, ["-h", fileName, infile, outfile]) ->
-      fmap (unlit fileName $ mkSelector xs) (readFile infile) >>= writeFile outfile
+      fmap (unlit fileName $ mkSelector xs) (readFileUtf8 infile) >>= writeFileUtf8 outfile
     _ -> do
       name <- getProgName
       hPutStrLn stderr ("usage: " ++ name ++ " [selector] -h label infile outfile")
       exitFailure
     where
       mkSelector = fromMaybe ("haskell" :&: Not "ignore") . parseSelector . unwords
+      readFileUtf8 name = openFile name ReadMode >>= \h -> hSetEncoding h utf8 >> hGetContents h
+      writeFileUtf8 name str = withFile name WriteMode (\h -> hSetEncoding h utf8 >> hPutStr h str)
 
 unlit :: FilePath -> Selector -> String -> String
 unlit fileName selector = unlines . concatMap formatCB . filter (toP selector . codeBlockClasses) . parse


### PR DESCRIPTION
Instead of using standard `readFile` and `writeFile` they are now reimplemented the same as in the library, but additionally they set UTF-8 encoding on the handles.