### PR TITLE
Append, not overwrite .ghci

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ At this point we can load the code into GHCi:
 Or better yet, pipe the required flag into a `.ghci` file, and forget about it:
 
 ```
-$ echo ':set -pgmL markdown-unlit' > .ghci
+$ echo ':set -pgmL markdown-unlit' >> .ghci
 ```
 ```
 $ ghci README.lhs


### PR DESCRIPTION
I just lost my `~/.ghci` as I simply copy pasted it; when I realized it was `>` I already pressed `RET`. I hope this doesn't happen to others.