### PR TITLE
Extra real world examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ modifications.
 
 ## Real world examples
 
- * [ClickHaskell](https://github.com/KovalevDima/ClickHaskell) documentation
- * [servant](https://github.com/haskell-servant/servant/tree/master/doc) documentation generation
+ * [ClickHaskell](https://github.com/KovalevDima/ClickHaskell/tree/master/QA)
+ * [servant](https://github.com/haskell-servant/servant/tree/master/doc)
  * [attoparsec-parsec](https://github.com/sol/attoparsec-parsec#readme)
  * [hspec-expectations](https://github.com/sol/hspec-expectations#readme)
  * [wai](https://github.com/yesodweb/wai/tree/master/wai#readme)

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ modifications.
 ## Real world examples
 
  * [ClickHaskell](https://github.com/KovalevDima/ClickHaskell) documentation
- * [servant](https://github.com/haskell-servant/servant) documentation
+ * [servant](https://github.com/haskell-servant/servant/tree/master/doc) documentation generation
  * [attoparsec-parsec](https://github.com/sol/attoparsec-parsec#readme)
  * [hspec-expectations](https://github.com/sol/hspec-expectations#readme)
  * [wai](https://github.com/yesodweb/wai/tree/master/wai#readme)

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ modifications.
 
 ## Real world examples
 
+ * [ClickHaskell](https://github.com/KovalevDima/ClickHaskell) documentation
+ * [servant](https://github.com/haskell-servant/servant) documentation
  * [attoparsec-parsec](https://github.com/sol/attoparsec-parsec#readme)
  * [hspec-expectations](https://github.com/sol/hspec-expectations#readme)
  * [wai](https://github.com/yesodweb/wai/tree/master/wai#readme)


### PR DESCRIPTION
`servant` is a successful example of usage `markdown-unlit` for documentation generation (passing .lhs as .md sources to [Sphinx](https://www.sphinx-doc.org/en/master/))
`ClickHaskell` is my project which uses `markdown-unlit` a lot for documentation generation (passing .hls as .md sources to [Hakyll](https://github.com/jaspervdj/hakyll) pandoc complier)