### PR TITLE
Test un-annotated code blocks when using Not

### DIFF
--- a/test/Text/Markdown/UnlitSpec.hs
+++ b/test/Text/Markdown/UnlitSpec.hs
@@ -138,9 +138,14 @@ spec = do
         "~~~ {.bar}"
         "2"
         "~~~"
+        "~~~"
+        "3"
+        "~~~"
       `shouldBe` (build $ do
         "#line 5 \"Foo.lhs\""
         "2"
+        "#line 8 \"Foo.lhs\""
+        "3"
         )
 
     it "can handle :&:" $ do


### PR DESCRIPTION
Adds a minor test case that a non-annotated code block matches `Not foo`.
